### PR TITLE
fix: correct the intopolation of packageName to packagename

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task('generate', gulp.series('generate-template', () => {
   fs.ensureDir("generated");
 
   // Interpolate
-  const parsePackageName = gulpReplace('packageName', config.domainPackage);
+  const parsePackageName = gulpReplace('packagename', config.domainPackage);
   const parseArtifactId = gulpReplace('artifactName',
       config.domainNameLowerCase);
   const parsePluralLowerCase = gulpReplace(/examples/g,
@@ -111,7 +111,7 @@ gulp.task('generate', gulp.series('generate-template', () => {
 
   // Update filename & file path
   const renamePackage = gulpRename(function (file) {
-    replaceName(file, 'packageName', config.newServicePath);
+    replaceName(file, 'packagename', config.newServicePath);
     replaceName(file, 'Example', config.domainNameStartCase);
   });
 


### PR DESCRIPTION
# Description
When we have `packageName' as the name of a package then its not a java standard because it should essentially be all lower case however we have used camelCase.

Closes : https://github.com/devs-from-matrix/app-generator/issues/19

# Checklist:

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
